### PR TITLE
ensure sample_fraction_ is passed as a vector

### DIFF
--- a/skranger/ensemble/base.py
+++ b/skranger/ensemble/base.py
@@ -1,4 +1,5 @@
 import warnings
+from collections.abc import Iterable
 
 import numpy as np
 
@@ -11,6 +12,8 @@ class RangerValidationMixin:
         self._evaluate_mtry(X.shape[1])
         self._set_importance_mode()
         self.sample_fraction_ = self.sample_fraction or [1.0 if self.replace else 0.632]
+        if not isinstance(self.sample_fraction_, Iterable):
+            self.sample_fraction_ = [self.sample_fraction_]
         self._check_inbag(sample_weights)
         self._check_set_regularization(X.shape[1])
         self._set_split_rule(y)

--- a/skranger/ensemble/ranger_forest_classifier.py
+++ b/skranger/ensemble/ranger_forest_classifier.py
@@ -69,7 +69,8 @@ class RangerForestClassifier(RangerValidationMixin, ClassifierMixin, BaseEstimat
     :ivar dict ranger_forest\_: The returned result object from calling C++ ranger.
     :ivar int mtry\_: The mtry value as determined if ``mtry`` is callable, otherwise
         it is the same as ``mtry``.
-    :ivar list sample_fraction\_: The sample fraction determined by input validation
+    :ivar float/list sample_fraction\_: The sample fraction determined by input
+        validation
     :ivar list regularization_factor\_: The regularization factors determined by input
         validation.
     :ivar list unordered_variable_names\_: The unordered variable names determined by

--- a/skranger/ensemble/ranger_forest_regressor.py
+++ b/skranger/ensemble/ranger_forest_regressor.py
@@ -18,7 +18,7 @@ class RangerForestRegressor(RangerValidationMixin, RegressorMixin, BaseEstimator
     argument names to the constructor are similar to the C++ library and accompanied R
     package for familiarity.
 
-    :param int n_estimators: The number of tree classifiers to train
+    :param int n_estimators: The number of tree regressors to train
     :param bool verbose: Enable ranger's verbose logging
     :param int/callable mtry: The number of features to split on each node. When a
         callable is passed, the function must accept a single parameter which is the
@@ -29,9 +29,8 @@ class RangerForestRegressor(RangerValidationMixin, RegressorMixin, BaseEstimator
     :param int min_node_size: The minimal node size.
     :param int max_depth: The maximal tree depth; 0 means unlimited.
     :param bool replace: Sample with replacement.
-    :param sample_fraction: The fraction of observations to sample. The default is 1
-        when sampling with replacement, and 0.632 otherwise. This can be a vector of
-        class specific values.
+    :param float sample_fraction: The fraction of observations to sample. The default is 1
+        when sampling with replacement, and 0.632 otherwise.
     :param bool keep_inbag: If true, save how often observations are in-bag in each
         tree. These will be stored in the ``ranger_forest_`` attribute under the key
         ``"inbag_counts"``.
@@ -74,7 +73,7 @@ class RangerForestRegressor(RangerValidationMixin, RegressorMixin, BaseEstimator
     :ivar dict ranger_forest\_: The returned result object from calling C++ ranger.
     :ivar int mtry\_: The mtry value as determined if ``mtry`` is callable, otherwise
         it is the same as ``mtry``.
-    :ivar list sample_fraction\_: The sample fraction determined by input validation
+    :ivar float sample_fraction\_: The sample fraction determined by input validation
     :ivar list regularization_factor\_: The regularization factors determined by input
         validation.
     :ivar list unordered_features\_: The unordered feature names determined by

--- a/skranger/ensemble/ranger_forest_survival.py
+++ b/skranger/ensemble/ranger_forest_survival.py
@@ -27,9 +27,8 @@ class RangerForestSurvival(RangerValidationMixin, BaseEstimator):
     :param int min_node_size: The minimal node size.
     :param int max_depth: The maximal tree depth; 0 means unlimited.
     :param bool replace: Sample with replacement.
-    :param sample_fraction: The fraction of observations to sample. The default is 1
-        when sampling with replacement, and 0.632 otherwise. This can be a vector of
-        class specific values.
+    :param float sample_fraction: The fraction of observations to sample. The default
+        is 1 when sampling with replacement, and 0.632 otherwise.
     :param bool keep_inbag: If true, save how often observations are in-bag in each
         tree. These will be stored in the ``ranger_forest_`` attribute under the key
         ``"inbag_counts"``.
@@ -69,7 +68,7 @@ class RangerForestSurvival(RangerValidationMixin, BaseEstimator):
     :ivar dict ranger_forest\_: The returned result object from calling C++ ranger.
     :ivar int mtry\_: The mtry value as determined if ``mtry`` is callable, otherwise
         it is the same as ``mtry``.
-    :ivar list sample_fraction\_: The sample fraction determined by input validation
+    :ivar float sample_fraction\_: The sample fraction determined by input validation.
     :ivar list regularization_factor\_: The regularization factors determined by input
         validation.
     :ivar list unordered_feature_names\_: The unordered feature names determined by

--- a/tests/ensemble/test_ranger_forest_classifier.py
+++ b/tests/ensemble/test_ranger_forest_classifier.py
@@ -137,6 +137,14 @@ class TestRangerForestClassifier:
         with pytest.raises(ValueError):
             rfc.fit(iris_X, iris_y)
 
+    def test_sample_fraction(self, iris_X, iris_y):
+        rfc = RangerForestClassifier(sample_fraction=[0.69])
+        rfc.fit(iris_X, iris_y)
+        assert rfc.sample_fraction_ == [0.69]
+        rfc = RangerForestClassifier(sample_fraction=0.69)
+        rfc.fit(iris_X, iris_y)
+        assert rfc.sample_fraction_ == [0.69]
+
     def test_sample_fraction_replace(self, iris_X, iris_y, replace):
         rfc = RangerForestClassifier(replace=replace)
         rfc.fit(iris_X, iris_y)

--- a/tests/ensemble/test_ranger_forest_regressor.py
+++ b/tests/ensemble/test_ranger_forest_regressor.py
@@ -120,6 +120,11 @@ class TestRangerForestRegressor:
         with pytest.raises(ValueError):
             rfc.fit(boston_X, boston_y)
 
+    def test_sample_fraction(self, iris_X, iris_y):
+        rfr = RangerForestRegressor(sample_fraction=0.69)
+        rfr.fit(iris_X, iris_y)
+        assert rfr.sample_fraction_ == [0.69]
+
     def test_sample_fraction_replace(self, boston_X, boston_y, replace):
         rfc = RangerForestRegressor(replace=replace)
         rfc.fit(boston_X, boston_y)

--- a/tests/ensemble/test_ranger_forest_survival.py
+++ b/tests/ensemble/test_ranger_forest_survival.py
@@ -135,6 +135,11 @@ class TestRangerForestSurvival:
         with pytest.raises(ValueError):
             rfc.fit(lung_X, lung_y)
 
+    def test_sample_fraction(self, iris_X, iris_y):
+        rfs = RangerForestSurvival(sample_fraction=0.69)
+        rfs.fit(iris_X, iris_y)
+        assert rfs.sample_fraction_ == [0.69]
+
     def test_sample_fraction_replace(self, lung_X, lung_y, replace):
         rfc = RangerForestSurvival(replace=replace)
         rfc.fit(lung_X, lung_y)

--- a/tests/ensemble/test_ranger_forest_survival.py
+++ b/tests/ensemble/test_ranger_forest_survival.py
@@ -135,9 +135,9 @@ class TestRangerForestSurvival:
         with pytest.raises(ValueError):
             rfc.fit(lung_X, lung_y)
 
-    def test_sample_fraction(self, iris_X, iris_y):
+    def test_sample_fraction(self, lung_X, lung_y):
         rfs = RangerForestSurvival(sample_fraction=0.69)
-        rfs.fit(iris_X, iris_y)
+        rfs.fit(lung_X, lung_y)
         assert rfs.sample_fraction_ == [0.69]
 
     def test_sample_fraction_replace(self, lung_X, lung_y, replace):


### PR DESCRIPTION
closes #58 

* Ranger expects a vector of values for `sample_fraction`, as it is generalized to sample for the number of classes used in classifiers. This adds some code to ensure it's passed as a list into the bindings
* Add some tests for each estimator
* Clarify types in docstrings for `sample_fraction`