### PR TITLE
dont pass sample_fraction_ at predict

### DIFF
--- a/skranger/ensemble/ranger_forest_classifier.py
+++ b/skranger/ensemble/ranger_forest_classifier.py
@@ -269,7 +269,7 @@ class RangerForestClassifier(RangerValidationMixin, ClassifierMixin, BaseEstimat
             self.class_weights or [],
             False,  # predict_all
             self.keep_inbag,
-            self.sample_fraction_,
+            [1],  # sample_fraction
             0.5,  # alpha
             0.1,  # minprop
             self.holdout,

--- a/skranger/ensemble/ranger_forest_regressor.py
+++ b/skranger/ensemble/ranger_forest_regressor.py
@@ -272,7 +272,7 @@ class RangerForestRegressor(RangerValidationMixin, RegressorMixin, BaseEstimator
             [],  # class_weights
             False,  # predict_all
             self.keep_inbag,
-            self.sample_fraction_,
+            [1],  # sample_fraction
             0,  # alpha
             0,  # minprop
             self.holdout,
@@ -354,7 +354,7 @@ class RangerForestRegressor(RangerValidationMixin, RegressorMixin, BaseEstimator
             [],  # class_weights
             False,  # predict_all
             self.keep_inbag,
-            self.sample_fraction_,
+            [1],  # sample_fraction
             self.alpha,
             self.minprop,
             self.holdout,

--- a/skranger/ensemble/ranger_forest_survival.py
+++ b/skranger/ensemble/ranger_forest_survival.py
@@ -255,7 +255,7 @@ class RangerForestSurvival(RangerValidationMixin, BaseEstimator):
             [],  # class_weights
             False,  # predict_all
             self.keep_inbag,
-            self.sample_fraction_,
+            [1],  # sample_fraction
             self.alpha,
             self.minprop,
             self.holdout,

--- a/tests/ensemble/test_ranger_forest_classifier.py
+++ b/tests/ensemble/test_ranger_forest_classifier.py
@@ -36,17 +36,32 @@ class TestRangerForestClassifier:
         pred = rfc.predict(iris_X)
         assert len(pred) == iris_X.shape[0]
 
+        # test with single record
+        iris_X_record = iris_X[0:1, :]
+        pred = rfc.predict(iris_X_record)
+        assert len(pred) == 1
+
     def test_predict_proba(self, iris_X, iris_y):
         rfc = RangerForestClassifier()
         rfc.fit(iris_X, iris_y)
         pred = rfc.predict_proba(iris_X)
         assert len(pred) == iris_X.shape[0]
 
+        # test with single record
+        iris_X_record = iris_X[0:1, :]
+        pred = rfc.predict_proba(iris_X_record)
+        assert len(pred) == 1
+
     def test_predict_log_proba(self, iris_X, iris_y):
         rfc = RangerForestClassifier()
         rfc.fit(iris_X, iris_y)
         pred = rfc.predict_log_proba(iris_X)
         assert len(pred) == iris_X.shape[0]
+
+        # test with single record
+        iris_X_record = iris_X[0:1, :]
+        pred = rfc.predict_log_proba(iris_X_record)
+        assert len(pred) == 1
 
     def test_serialize(self, iris_X, iris_y):
         tf = tempfile.TemporaryFile()
@@ -144,6 +159,15 @@ class TestRangerForestClassifier:
         rfc = RangerForestClassifier(sample_fraction=0.69)
         rfc.fit(iris_X, iris_y)
         assert rfc.sample_fraction_ == [0.69]
+
+        # test with single record
+        iris_X_record = iris_X[0:1, :]
+        pred = rfc.predict(iris_X_record)
+        assert len(pred) == 1
+        pred = rfc.predict_proba(iris_X_record)
+        assert len(pred) == 1
+        pred = rfc.predict_log_proba(iris_X_record)
+        assert len(pred) == 1
 
     def test_sample_fraction_replace(self, iris_X, iris_y, replace):
         rfc = RangerForestClassifier(replace=replace)

--- a/tests/ensemble/test_ranger_forest_regressor.py
+++ b/tests/ensemble/test_ranger_forest_regressor.py
@@ -31,6 +31,11 @@ class TestRangerForestRegressor:
         pred = rfr.predict(boston_X)
         assert len(pred) == boston_X.shape[0]
 
+        # test with single record
+        boston_X_record = boston_X[0:1, :]
+        pred = rfr.predict(boston_X_record)
+        assert len(pred) == 1
+
     def test_serialize(self, boston_X, boston_y):
         tf = tempfile.TemporaryFile()
         rfr = RangerForestRegressor()
@@ -124,6 +129,11 @@ class TestRangerForestRegressor:
         rfr = RangerForestRegressor(sample_fraction=0.69)
         rfr.fit(iris_X, iris_y)
         assert rfr.sample_fraction_ == [0.69]
+
+        # test with single record
+        iris_X_record = iris_X[0:1, :]
+        pred = rfr.predict(iris_X_record)
+        assert len(pred) == 1
 
     def test_sample_fraction_replace(self, boston_X, boston_y, replace):
         rfr = RangerForestRegressor(replace=replace)

--- a/tests/ensemble/test_ranger_forest_survival.py
+++ b/tests/ensemble/test_ranger_forest_survival.py
@@ -34,6 +34,11 @@ class TestRangerForestSurvival:
         pred = rfs.predict(lung_X)
         assert len(pred) == lung_X.shape[0]
 
+        # test with single record
+        lung_X_record = lung_X.values[0:1, :]
+        pred = rfs.predict(lung_X_record)
+        assert len(pred) == 1
+
     def test_predict_cumulative_hazard_function(self, lung_X, lung_y):
         rfs = RangerForestSurvival(n_estimators=N_ESTIMATORS)
         rfs.fit(lung_X, lung_y)
@@ -139,6 +144,11 @@ class TestRangerForestSurvival:
         rfs = RangerForestSurvival(sample_fraction=0.69)
         rfs.fit(lung_X, lung_y)
         assert rfs.sample_fraction_ == [0.69]
+
+        # test with single record
+        lung_X_record = lung_X.values[0:1, :]
+        pred = rfs.predict(lung_X_record)
+        assert len(pred) == 1
 
     def test_sample_fraction_replace(self, lung_X, lung_y, replace):
         rfs = RangerForestSurvival(replace=replace)


### PR DESCRIPTION
Closes #61 

When predicting we pass the validated `sample_fraction_` to ranger. Ranger, on creating the Forest object, performs a validation check against sample_fraction. We pass a valid sample fraction value (not the one specified by the user) on predict which ensures this check never fails on predict calls, since it is only ever used in fitting.