### PR TITLE
add check_estimator tests

### DIFF
--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -73,7 +73,7 @@ qtconsole==4.7.5
 qtpy==1.9.0
 regex==2020.6.8; python_version >= "3.6"
 requests==2.24.0; python_version >= "3.5" and python_full_version < "3.0.0" or python_full_version >= "3.5.0" and python_version >= "3.5"
-scikit-learn==0.23.1; python_version >= "3.6"
+scikit-learn==0.22.2; python_version >= "3.6"
 scikit-survival==0.12.0; python_version >= "3.5"
 scipy==1.5.1; python_version >= "3.6"
 send2trash==1.5.0; python_version >= "3.5"

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -73,7 +73,7 @@ qtconsole==4.7.5
 qtpy==1.9.0
 regex==2020.6.8; python_version >= "3.6"
 requests==2.24.0; python_version >= "3.5" and python_full_version < "3.0.0" or python_full_version >= "3.5.0" and python_version >= "3.5"
-scikit-learn==0.22.0; python_version >= "3.6"
+scikit-learn==0.23.1; python_version >= "3.6"
 scikit-survival==0.12.0; python_version >= "3.5"
 scipy==1.5.1; python_version >= "3.6"
 send2trash==1.5.0; python_version >= "3.5"

--- a/skranger/ensemble/base.py
+++ b/skranger/ensemble/base.py
@@ -160,13 +160,3 @@ class RangerValidationMixin:
                 raise ValueError("Cannot use class sampling and inbag.")
             if len(self.inbag) != self.n_estimators:
                 raise ValueError("Size of inbag must be equal to n_estimators.")
-
-    def _check_n_features(self, X):
-        """Ensure predict feature quantity matches fit feature quantity."""
-        n_features = X.shape[1]
-
-        if n_features != self.n_features_:
-            raise ValueError(
-                f"X has {n_features} features, but {self.__class__.__name__} "
-                f"is expecting {self.n_features_} features as input."
-            )

--- a/skranger/ensemble/ranger_forest_classifier.py
+++ b/skranger/ensemble/ranger_forest_classifier.py
@@ -2,7 +2,6 @@
 import numpy as np
 from sklearn.base import BaseEstimator
 from sklearn.base import ClassifierMixin
-from sklearn.utils import check_X_y
 from sklearn.utils.multiclass import check_classification_targets
 from sklearn.utils.validation import _check_sample_weight
 from sklearn.utils.validation import check_array

--- a/skranger/ensemble/ranger_forest_classifier.py
+++ b/skranger/ensemble/ranger_forest_classifier.py
@@ -65,7 +65,8 @@ class RangerForestClassifier(RangerValidationMixin, ClassifierMixin, BaseEstimat
 
     :ivar list classes\_: The class labels determined from the fit input ``y``.
     :ivar int n_classes\_: The number of unique class labels from the fit input ``y``.
-    :ivar int n_features\_: The number of features (columns) from the fit input ``X``.
+    :ivar int n_features_in\_: The number of features (columns) from the fit input
+        ``X``.
     :ivar list feature_names\_: Names for the features of the fit input ``X``.
     :ivar dict ranger_forest\_: The returned result object from calling C++ ranger.
     :ivar int mtry\_: The mtry value as determined if ``mtry`` is callable, otherwise
@@ -80,6 +81,8 @@ class RangerForestClassifier(RangerValidationMixin, ClassifierMixin, BaseEstimat
         ``SplitRule``.
     :ivar bool use_regularization_factor\_: Input validation determined bool for using
         regularization factor input parameter.
+    :ivar str respect_categorical_features\_: Input validation determined string
+        respecting categorical features.
     :ivar int importance_mode\_: The importance mode integer corresponding to ranger
         enum ``ImportanceMode``.
     :ivar list ranger_class_order\_: The class reference ordering derived from ranger.
@@ -151,7 +154,7 @@ class RangerForestClassifier(RangerValidationMixin, ClassifierMixin, BaseEstimat
         self.tree_type_ = 9  # tree_type, TREE_PROBABILITY enables predict_proba
 
         # Check input
-        X, y = check_X_y(X, y)
+        X, y = self._validate_data(X, y)
         check_classification_targets(y)
 
         # Check the init parameters
@@ -176,7 +179,7 @@ class RangerForestClassifier(RangerValidationMixin, ClassifierMixin, BaseEstimat
 
         # Set X info
         self.feature_names_ = [str(c).encode() for c in range(X.shape[1])]
-        self.n_features_ = X.shape[1]
+        self._check_n_features(X, reset=True)
 
         if self.always_split_features is not None:
             always_split_features = [str(c).encode() for c in self.always_split_features]
@@ -249,7 +252,7 @@ class RangerForestClassifier(RangerValidationMixin, ClassifierMixin, BaseEstimat
         """
         check_is_fitted(self)
         X = check_array(X)
-        self._check_n_features(X)
+        self._check_n_features(X, reset=False)
 
         result = ranger.ranger(
             self.tree_type_,

--- a/skranger/ensemble/ranger_forest_regressor.py
+++ b/skranger/ensemble/ranger_forest_regressor.py
@@ -2,7 +2,6 @@
 import numpy as np
 from sklearn.base import BaseEstimator
 from sklearn.base import RegressorMixin
-from sklearn.utils import check_X_y
 from sklearn.utils.validation import _check_sample_weight
 from sklearn.utils.validation import check_array
 from sklearn.utils.validation import check_is_fitted

--- a/skranger/ensemble/ranger_forest_survival.py
+++ b/skranger/ensemble/ranger_forest_survival.py
@@ -63,7 +63,7 @@ class RangerForestSurvival(RangerValidationMixin, BaseEstimator):
     :param int n_jobs: The number of threads. Default is number of CPU cores.
     :param int seed: Random seed value.
 
-    :ivar int n_features\_: The number of features (columns) from the fit input ``X``.
+    :ivar int n_features_in\_: The number of features (columns) from the fit input ``X``.
     :ivar list feature_names\_: Names for the features of the fit input ``X``.
     :ivar dict ranger_forest\_: The returned result object from calling C++ ranger.
     :ivar int mtry\_: The mtry value as determined if ``mtry`` is callable, otherwise
@@ -77,6 +77,8 @@ class RangerForestSurvival(RangerValidationMixin, BaseEstimator):
         ``SplitRule``.
     :ivar bool use_regularization_factor\_: Input validation determined bool for using
         regularization factor input parameter.
+    :ivar str respect_categorical_features\_: Input validation determined string
+        respecting categorical features.
     :ivar int importance_mode\_: The importance mode integer corresponding to ranger
         enum ``ImportanceMode``.
     """
@@ -172,7 +174,7 @@ class RangerForestSurvival(RangerValidationMixin, BaseEstimator):
 
         # Set X info
         self.feature_names_ = [str(c).encode() for c in range(X.shape[1])]
-        self.n_features_ = X.shape[1]
+        self._check_n_features(X, reset=True)
 
         if self.always_split_features is not None:
             always_split_features = [str(c).encode() for c in self.always_split_features]
@@ -237,7 +239,7 @@ class RangerForestSurvival(RangerValidationMixin, BaseEstimator):
     def _predict(self, X):
         check_is_fitted(self)
         X = check_array(X)
-        self._check_n_features(X)
+        self._check_n_features(X, reset=False)
 
         result = ranger.ranger(
             self.tree_type_,
@@ -311,3 +313,6 @@ class RangerForestSurvival(RangerValidationMixin, BaseEstimator):
         """
         chf = self.predict_cumulative_hazard_function(X)
         return chf.sum(1)
+
+    def _more_tags(self):
+        return {"requires_y": True}

--- a/skranger/ensemble/ranger_forest_survival.py
+++ b/skranger/ensemble/ranger_forest_survival.py
@@ -146,18 +146,29 @@ class RangerForestSurvival(RangerValidationMixin, BaseEstimator):
         :param array1d sample_weight: optional weights for input samples
         """
         self.tree_type_ = 5  # tree_type, TREE_SURVIVAL
+
         # Check input
         X = check_array(X)
+
         # convert 1d array of 2tuples to 2d array
         # ranger expects the time first, and status second
         # since we follow the scikit-survival convention, we fliplr
         y = np.fliplr(np.array(y.tolist()))
 
-        if sample_weight is not None:
-            sample_weight = _check_sample_weight(sample_weight, X)
-
         # Check the init parameters
         self._validate_parameters(X, y, sample_weight)
+
+        if sample_weight is not None:
+            sample_weight = _check_sample_weight(sample_weight, X)
+            use_sample_weight = True
+            # ranger does additional rng on samples if weights are passed.
+            # if the weights are ones, then we dont want that extra rng.
+            if np.array_equal(np.unique(sample_weight), np.array([1.0])):
+                sample_weight = []
+                use_sample_weight = False
+        else:
+            sample_weight = []
+            use_sample_weight = False
 
         # Set X info
         self.feature_names_ = [str(c).encode() for c in range(X.shape[1])]
@@ -195,8 +206,8 @@ class RangerForestSurvival(RangerValidationMixin, BaseEstimator):
             bool(self.categorical_features_),  # use_unordered_features
             False,  # save_memory
             self.split_rule_,
-            sample_weight or [],  # case_weights
-            bool(sample_weight),  # use_case_weights
+            sample_weight,  # case_weights
+            use_sample_weight,  # use_case_weights
             [],  # class_weights
             False,  # predict_all
             self.keep_inbag,
@@ -226,6 +237,7 @@ class RangerForestSurvival(RangerValidationMixin, BaseEstimator):
     def _predict(self, X):
         check_is_fitted(self)
         X = check_array(X)
+        self._check_n_features(X)
 
         result = ranger.ranger(
             self.tree_type_,

--- a/tests/ensemble/test_ranger_forest_classifier.py
+++ b/tests/ensemble/test_ranger_forest_classifier.py
@@ -9,6 +9,7 @@ from sklearn.ensemble import RandomForestClassifier
 from sklearn.exceptions import NotFittedError
 from sklearn.metrics import accuracy_score
 from sklearn.model_selection import train_test_split
+from sklearn.utils.estimator_checks import check_estimator
 from sklearn.utils.validation import check_is_fitted
 
 from skranger.ensemble import RangerForestClassifier
@@ -287,3 +288,6 @@ class TestRangerForestClassifier:
         # the accuracy should be good
         assert rf_acc > 0.9
         assert ranger_acc > 0.9
+
+    def test_check_estimator(self):
+        check_estimator(RangerForestClassifier)

--- a/tests/ensemble/test_ranger_forest_classifier.py
+++ b/tests/ensemble/test_ranger_forest_classifier.py
@@ -29,7 +29,7 @@ class TestRangerForestClassifier:
         assert hasattr(rfc, "n_classes_")
         assert hasattr(rfc, "ranger_forest_")
         assert hasattr(rfc, "ranger_class_order_")
-        assert hasattr(rfc, "n_features_")
+        assert hasattr(rfc, "n_features_in_")
 
     def test_predict(self, iris_X, iris_y):
         rfc = RangerForestClassifier()
@@ -290,4 +290,4 @@ class TestRangerForestClassifier:
         assert ranger_acc > 0.9
 
     def test_check_estimator(self):
-        check_estimator(RangerForestClassifier)
+        check_estimator(RangerForestClassifier())

--- a/tests/ensemble/test_ranger_forest_regressor.py
+++ b/tests/ensemble/test_ranger_forest_regressor.py
@@ -24,7 +24,7 @@ class TestRangerForestRegressor:
         rfr.fit(boston_X, boston_y)
         check_is_fitted(rfr)
         assert hasattr(rfr, "ranger_forest_")
-        assert hasattr(rfr, "n_features_")
+        assert hasattr(rfr, "n_features_in_")
 
     def test_predict(self, boston_X, boston_y):
         rfr = RangerForestRegressor()
@@ -256,4 +256,4 @@ class TestRangerForestRegressor:
         assert quantiles.ndim == 2
 
     def test_check_estimator(self):
-        check_estimator(RangerForestRegressor)
+        check_estimator(RangerForestRegressor())

--- a/tests/ensemble/test_ranger_forest_regressor.py
+++ b/tests/ensemble/test_ranger_forest_regressor.py
@@ -7,6 +7,7 @@ import pytest
 from sklearn.base import clone
 from sklearn.exceptions import NotFittedError
 from sklearn.model_selection import train_test_split
+from sklearn.utils.estimator_checks import check_estimator
 from sklearn.utils.validation import check_is_fitted
 
 from skranger.ensemble import RangerForestRegressor
@@ -253,3 +254,6 @@ class TestRangerForestRegressor:
         assert quantiles_upper.ndim == 1
         quantiles = rfr.predict_quantiles(X_test, quantiles=[0.1, 0.9])
         assert quantiles.ndim == 2
+
+    def test_check_estimator(self):
+        check_estimator(RangerForestRegressor)

--- a/tests/ensemble/test_ranger_forest_survival.py
+++ b/tests/ensemble/test_ranger_forest_survival.py
@@ -6,6 +6,7 @@ import numpy as np
 import pytest
 from sklearn.base import clone
 from sklearn.exceptions import NotFittedError
+from sklearn.utils.estimator_checks import check_estimator
 from sklearn.utils.validation import check_is_fitted
 
 from skranger.ensemble import RangerForestSurvival
@@ -241,3 +242,19 @@ class TestRangerForestSurvival:
         # feature 0 is in every tree split
         for tree in rfs.ranger_forest_["forest"]["split_var_ids"]:
             assert 0 in tree
+
+    def test_sample_weight(self, lung_X, lung_y):
+        rfs_w = RangerForestSurvival()
+        rfs_w.fit(lung_X, lung_y, sample_weight=[1] * len(lung_y))
+        rfs = RangerForestSurvival()
+        rfs.fit(lung_X, lung_y)
+
+        pred_w = rfs_w.predict(lung_X)
+        pred = rfs.predict(lung_X)
+
+        np.testing.assert_array_equal(pred.reshape(-1, 1), pred_w.reshape(-1, 1))
+
+    # We can't check this because we conform to scikit-survival api,
+    # rather than scikit-learn's
+    # def test_check_estimator(self):
+    #     check_estimator(RangerForestSurvival)

--- a/tests/ensemble/test_ranger_forest_survival.py
+++ b/tests/ensemble/test_ranger_forest_survival.py
@@ -27,7 +27,7 @@ class TestRangerForestSurvival:
         assert hasattr(rfs, "event_times_")
         assert hasattr(rfs, "cumulative_hazard_function_")
         assert hasattr(rfs, "ranger_forest_")
-        assert hasattr(rfs, "n_features_")
+        assert hasattr(rfs, "n_features_in_")
 
     def test_predict(self, lung_X, lung_y):
         rfs = RangerForestSurvival(n_estimators=N_ESTIMATORS)
@@ -254,7 +254,12 @@ class TestRangerForestSurvival:
 
         np.testing.assert_array_equal(pred.reshape(-1, 1), pred_w.reshape(-1, 1))
 
+    def test_get_tags(self):
+        rfs = RangerForestSurvival()
+        tags = rfs._get_tags()
+        assert tags["requires_y"]
+
     # We can't check this because we conform to scikit-survival api,
     # rather than scikit-learn's
     # def test_check_estimator(self):
-    #     check_estimator(RangerForestSurvival)
+    #     check_estimator(RangerForestSurvival())


### PR DESCRIPTION
Add `check_estimator` tests to classifier and regressor. We can't test the survival forest because it conforms to the sksurv api rather than sklearn's.

In doing so we add validation to ensure `check_estimator` passes. We also add logic to ensure that passing `sample_weight` of ones is equivalent to passing `None`.

Changes:
* Ensure `self.respect_categorical_features` is unchanged when fitting by introducing `self.respect_categorical_features_`
* Change `self.n_features_` to `self.n_features_in_`
* Add validation to classification targets, ensuring regression targets can't be passed to classifier
* Add sample weight validation to ensure that passing weights of `ones` results in identical output when passing `None`. We do this because ranger does additional RNG on weighted sampling when non-null weights are passed.
* Use `self._validate_data` in lieu of `check_X_y` when possible
* Use `self._check_n_features` in lieu of manually setting n features
* Manually add estimator tags to survival forest

https://scikit-learn.org/stable/modules/generated/sklearn.utils.estimator_checks.check_estimator.html