### PR TITLE
fix class weights bug and move to fit

### DIFF
--- a/skranger/ensemble/ranger_forest_regressor.py
+++ b/skranger/ensemble/ranger_forest_regressor.py
@@ -224,7 +224,7 @@ class RangerForestRegressor(RangerMixin, RegressorMixin, BaseEstimator):
             self.split_rule_,
             sample_weight,  # case_weights
             use_sample_weight,  # use_case_weights
-            [],  # class_weights
+            {},  # class_weights
             False,  # predict_all
             self.keep_inbag,
             self.sample_fraction_,
@@ -289,7 +289,7 @@ class RangerForestRegressor(RangerMixin, RegressorMixin, BaseEstimator):
             1,  # split_rule
             [],  # case_weights
             False,  # use_case_weights
-            [],  # class_weights
+            {},  # class_weights
             False,  # predict_all
             self.keep_inbag,
             [1],  # sample_fraction
@@ -380,7 +380,7 @@ class RangerForestRegressor(RangerMixin, RegressorMixin, BaseEstimator):
             self.split_rule_,
             [],  # case_weights
             False,  # use_case_weights
-            [],  # class_weights
+            {},  # class_weights
             False,  # predict_all
             self.keep_inbag,
             [1],  # sample_fraction

--- a/skranger/ensemble/ranger_forest_survival.py
+++ b/skranger/ensemble/ranger_forest_survival.py
@@ -212,7 +212,7 @@ class RangerForestSurvival(RangerMixin, BaseEstimator):
             self.split_rule_,
             sample_weight,  # case_weights
             use_sample_weight,  # use_case_weights
-            [],  # class_weights
+            {},  # class_weights
             False,  # predict_all
             self.keep_inbag,
             self.sample_fraction_,
@@ -270,7 +270,7 @@ class RangerForestSurvival(RangerMixin, BaseEstimator):
             self.split_rule_,
             [],  # case_weights
             False,  # use_case_weights
-            [],  # class_weights
+            {},  # class_weights
             False,  # predict_all
             self.keep_inbag,
             [1],  # sample_fraction

--- a/tests/ensemble/test_ranger_forest_classifier.py
+++ b/tests/ensemble/test_ranger_forest_classifier.py
@@ -266,7 +266,6 @@ class TestRangerForestClassifier:
         X_train, X_test, y_train, y_test = train_test_split(
             iris_X, iris_y, test_size=0.5, random_state=42
         )
-        y_train = np.flip(y_train)
         forest = RangerForestClassifier()
         weights = {
             0: 0.7,

--- a/tests/ensemble/test_ranger_forest_classifier.py
+++ b/tests/ensemble/test_ranger_forest_classifier.py
@@ -5,6 +5,7 @@ import tempfile
 import numpy as np
 import pytest
 from sklearn.base import clone
+from sklearn.datasets import load_digits
 from sklearn.ensemble import RandomForestClassifier
 from sklearn.exceptions import NotFittedError
 from sklearn.metrics import accuracy_score
@@ -261,6 +262,37 @@ class TestRangerForestClassifier:
             forest = RangerForestClassifier(split_rule=split_rule, num_random_splits=2)
             with pytest.raises(ValueError):
                 forest.fit(iris_X, iris_y)
+
+    def test_class_weights(self, iris_X, iris_y):
+        X_train, X_test, y_train, y_test = train_test_split(
+            iris_X, iris_y, test_size=0.5, random_state=42
+        )
+        y_train = np.flip(y_train)
+        forest = RangerForestClassifier()
+        weights = {
+            0: 0.7,
+            1: 0.2,
+            2: 0.1,
+        }
+        forest.fit(X_train, y_train, class_weights=weights)
+        forest.predict(X_test)
+
+        forest = RangerForestClassifier()
+        m = {0: "a", 1: "b", 2: "c"}
+        y_train_str = [m.get(v) for v in y_train]
+        weights = {
+            "a": 0.7,
+            "b": 0.2,
+            "c": 0.1,
+        }
+        forest.fit(X_train, y_train_str, class_weights=weights)
+        forest.predict(X_test)
+
+        weights = {
+            0: 0.7,
+        }
+        with pytest.raises(ValueError):
+            forest.fit(X_train, y_train, class_weights=weights)
 
     def test_split_select_weights(self, iris_X, iris_y):
         n_trees = 10

--- a/tests/ensemble/test_ranger_forest_classifier.py
+++ b/tests/ensemble/test_ranger_forest_classifier.py
@@ -5,7 +5,6 @@ import tempfile
 import numpy as np
 import pytest
 from sklearn.base import clone
-from sklearn.datasets import load_digits
 from sklearn.ensemble import RandomForestClassifier
 from sklearn.exceptions import NotFittedError
 from sklearn.metrics import accuracy_score


### PR DESCRIPTION
Moves `class_weights` to fit in classifier, and changes the arg type to a dictionary. On the python side we store classes as a sorted array of target values but in ranger they are stored in the order in which they appear in the training target set as floats (?). For this reason we accept class weights as a dictionary, and we must map the weights to the class index on the python side and then re-order them as they exists in the ranger `class_values` array in Cython.