### PR TITLE
make tree prep operations optional

### DIFF
--- a/skranger/ensemble/classifier.py
+++ b/skranger/ensemble/classifier.py
@@ -58,7 +58,7 @@ class RangerForestClassifier(BaseRangerForest, ClassifierMixin, BaseEstimator):
     :param int seed: Random seed value.
     :param bool enable_tree_details: When ``True``, perform additional calculations
         for building the underlying decision trees. Must be enabled for ``estimators_``
-        and ``get_estimator`` to work.
+        and ``get_estimator`` to work. Very slow.
 
     :ivar ndarray classes\_: The class labels determined from the fit input ``y``.
     :ivar int n_classes\_: The number of unique class labels from the fit input ``y``.

--- a/skranger/ensemble/regressor.py
+++ b/skranger/ensemble/regressor.py
@@ -1,4 +1,6 @@
 """Scikit-learn wrapper for ranger regression."""
+import logging
+
 import numpy as np
 from sklearn.base import BaseEstimator
 from sklearn.base import RegressorMixin
@@ -63,7 +65,7 @@ class RangerForestRegressor(BaseRangerForest, RegressorMixin, BaseEstimator):
     :param int seed: Random seed value.
     :param bool enable_tree_details: When ``True``, perform additional calculations
         for building the underlying decision trees. Must be enabled for ``estimators_``
-        and ``get_estimator`` to work.
+        and ``get_estimator`` to work. Very slow.
 
     :ivar int n_features_in\_: The number of features (columns) from the fit input
         ``X``.
@@ -276,7 +278,6 @@ class RangerForestRegressor(BaseRangerForest, RegressorMixin, BaseEstimator):
         # build the leaf samples
         terminal_node_forest = self._get_terminal_node_forest(X)
         terminal_nodes = np.atleast_2d(terminal_node_forest["predictions"]).astype(int)
-        self._set_leaf_samples(terminal_nodes)
 
         if self.quantiles:
             self.random_node_values_ = np.empty(
@@ -289,6 +290,7 @@ class RangerForestRegressor(BaseRangerForest, RegressorMixin, BaseEstimator):
                 self.random_node_values_[terminal_nodes[idx, tree], tree] = y[idx]
 
         if self.enable_tree_details:
+            self._set_leaf_samples(terminal_nodes)
             self._set_sample_weights(sample_weight)
             self._set_node_values(y, sample_weight)
             self._set_n_classes()

--- a/skranger/ensemble/regressor.py
+++ b/skranger/ensemble/regressor.py
@@ -1,6 +1,4 @@
 """Scikit-learn wrapper for ranger regression."""
-import logging
-
 import numpy as np
 from sklearn.base import BaseEstimator
 from sklearn.base import RegressorMixin

--- a/skranger/ensemble/survival.py
+++ b/skranger/ensemble/survival.py
@@ -58,7 +58,7 @@ class RangerForestSurvival(BaseRangerForest, BaseEstimator):
     :param int seed: Random seed value.
     :param bool enable_tree_details: When ``True``, perform additional calculations
         for building the underlying decision trees. Must be enabled for ``estimators_``
-        and ``get_estimator`` to work.
+        and ``get_estimator`` to work. Very slow.
 
     :ivar int n_features_in\_: The number of features (columns) from the fit input ``X``.
     :ivar list feature_names\_: Names for the features of the fit input ``X``.

--- a/tests/ensemble/test_classifier.py
+++ b/tests/ensemble/test_classifier.py
@@ -395,6 +395,10 @@ class TestRangerForestClassifier:
         with pytest.raises(AttributeError):
             _ = forest.estimators_
         forest.fit(iris_X, iris_y)
+        with pytest.raises(ValueError):
+            _ = forest.estimators_
+        forest = RangerForestClassifier(n_estimators=10, enable_tree_details=True)
+        forest.fit(iris_X, iris_y)
         estimators = forest.estimators_
         assert len(estimators) == 10
         assert isinstance(estimators[0], RangerTreeClassifier)
@@ -405,9 +409,11 @@ class TestRangerForestClassifier:
         with pytest.raises(NotFittedError):
             _ = forest.get_estimator(idx=0)
         forest.fit(iris_X, iris_y)
-        forest.predict(iris_X)
+        with pytest.raises(ValueError):
+            _ = forest.get_estimator(0)
+        forest = RangerForestClassifier(n_estimators=10, enable_tree_details=True)
+        forest.fit(iris_X, iris_y)
         estimator = forest.get_estimator(0)
-        check_is_fitted(estimator)
         estimator.predict(iris_X)
         assert isinstance(estimator, RangerTreeClassifier)
         with pytest.raises(IndexError):

--- a/tests/ensemble/test_regressor.py
+++ b/tests/ensemble/test_regressor.py
@@ -346,6 +346,10 @@ class TestRangerForestRegressor:
         with pytest.raises(AttributeError):
             _ = forest.estimators_
         forest.fit(boston_X, boston_y)
+        with pytest.raises(ValueError):
+            _ = forest.estimators_
+        forest = RangerForestRegressor(n_estimators=10, enable_tree_details=True)
+        forest.fit(boston_X, boston_y)
         estimators = forest.estimators_
         assert len(estimators) == 10
         assert isinstance(estimators[0], RangerTreeRegressor)
@@ -356,9 +360,11 @@ class TestRangerForestRegressor:
         with pytest.raises(NotFittedError):
             _ = forest.get_estimator(idx=0)
         forest.fit(boston_X, boston_y)
-        forest.predict(boston_X)
+        with pytest.raises(ValueError):
+            _ = forest.get_estimator(0)
+        forest = RangerForestRegressor(n_estimators=10, enable_tree_details=True)
+        forest.fit(boston_X, boston_y)
         estimator = forest.get_estimator(0)
-        check_is_fitted(estimator)
         estimator.predict(boston_X)
         assert isinstance(estimator, RangerTreeRegressor)
         with pytest.raises(IndexError):

--- a/tests/ensemble/test_survival.py
+++ b/tests/ensemble/test_survival.py
@@ -326,6 +326,10 @@ class TestRangerForestSurvival:
         with pytest.raises(AttributeError):
             _ = forest.estimators_
         forest.fit(lung_X, lung_y)
+        with pytest.raises(ValueError):
+            _ = forest.estimators_
+        forest = RangerForestSurvival(n_estimators=10, enable_tree_details=True)
+        forest.fit(lung_X, lung_y)
         estimators = forest.estimators_
         assert len(estimators) == 10
         assert isinstance(estimators[0], RangerTreeSurvival)
@@ -336,9 +340,11 @@ class TestRangerForestSurvival:
         with pytest.raises(NotFittedError):
             _ = forest.get_estimator(idx=0)
         forest.fit(lung_X, lung_y)
-        forest.predict(lung_X)
+        with pytest.raises(ValueError):
+            _ = forest.get_estimator(0)
+        forest = RangerForestSurvival(n_estimators=10, enable_tree_details=True)
+        forest.fit(lung_X, lung_y)
         estimator = forest.get_estimator(0)
-        check_is_fitted(estimator)
         estimator.predict(lung_X)
         assert isinstance(estimator, RangerTreeSurvival)
         with pytest.raises(IndexError):

--- a/tests/test_tools.py
+++ b/tests/test_tools.py
@@ -3,7 +3,7 @@ import pytest
 from skranger.ensemble import RangerForestRegressor
 
 
-# @pytest.mark.skip()
+@pytest.mark.skip()
 def test_plot():
     from matplotlib import pyplot as plt
     from sklearn.datasets import load_boston

--- a/tests/test_tools.py
+++ b/tests/test_tools.py
@@ -3,14 +3,14 @@ import pytest
 from skranger.ensemble import RangerForestRegressor
 
 
-@pytest.mark.skip()
+# @pytest.mark.skip()
 def test_plot():
     from matplotlib import pyplot as plt
     from sklearn.datasets import load_boston
     from sklearn.tree import plot_tree
 
     boston_X, boston_y = load_boston(return_X_y=True)
-    forest = RangerForestRegressor()
+    forest = RangerForestRegressor(enable_tree_details=True)
     forest.fit(boston_X, boston_y)
     estimator = forest.get_estimator(0)
     plt.figure()


### PR DESCRIPTION
Computation which enables decision tree estimator and related details is expensive and not well optimized. Here we make those calculations optional.