### PR TITLE
fix value for classifier

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -266,14 +266,14 @@ python-versions = ">=3.6"
 
 [[package]]
 name = "packaging"
-version = "20.9"
+version = "21.3"
 description = "Core utilities for Python packages"
 category = "dev"
 optional = false
-python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*"
+python-versions = ">=3.6"
 
 [package.dependencies]
-pyparsing = ">=2.0.2"
+pyparsing = ">=2.0.2,<3.0.5 || >3.0.5"
 
 [[package]]
 name = "pandas"
@@ -992,8 +992,8 @@ numpy = [
     {file = "numpy-1.19.5.zip", hash = "sha256:a76f502430dd98d7546e1ea2250a7360c065a5fdea52b2dffe8ae7180909b6f4"},
 ]
 packaging = [
-    {file = "packaging-20.9-py2.py3-none-any.whl", hash = "sha256:67714da7f7bc052e064859c05c595155bd1ee9f69f76557e21f051443c20947a"},
-    {file = "packaging-20.9.tar.gz", hash = "sha256:5b327ac1320dc863dca72f4514ecc086f31186744b84a230374cc1fd776feae5"},
+    {file = "packaging-21.3-py3-none-any.whl", hash = "sha256:ef103e05f519cdc783ae24ea4e2e0f508a9c99b2d4969652eed6a2e1ea5bd522"},
+    {file = "packaging-21.3.tar.gz", hash = "sha256:dd47c42927d89ab911e606518907cc2d3a1f38bbd026385970643f9c5b8ecfeb"},
 ]
 pandas = [
     {file = "pandas-1.1.5-cp36-cp36m-macosx_10_9_x86_64.whl", hash = "sha256:bf23a3b54d128b50f4f9d4675b3c1857a688cc6731a32f931837d72effb2698d"},

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -41,7 +41,7 @@ pandas = "^1.0.3"
 pytest-cov = "^2.9.0"
 matplotlib = "^3.3.2"
 pytest-xdist = "^2.3.0"
-#shap = "^0.39.0"
+#shap = "^0.40.0"
 
 [build-system]
 requires = ["poetry>=0.12", "cython", "oldest-supported-numpy"]

--- a/skranger/base.py
+++ b/skranger/base.py
@@ -299,10 +299,18 @@ class RangerMixin:
             self._get_values(
                 left, right, root, weights,
             )
-            values = [
-                np.average(v, weights=w, axis=0) if v else np.nan
-                for v, w in zip(values, weights)
-            ]
+            if self._estimator_type == "classifier":
+                values = [
+                    np.bincount(v, weights=w, minlength=self.n_classes_).tolist()
+                    if v
+                    else np.nan
+                    for v, w in zip(values, weights)
+                ]
+            else:
+                values = [
+                    np.average(v, weights=w, axis=0) if v else np.nan
+                    for v, w in zip(values, weights)
+                ]
             self.ranger_forest_["forest"]["node_values"].append(values)
 
     def _set_n_classes(self):

--- a/skranger/base.py
+++ b/skranger/base.py
@@ -299,7 +299,7 @@ class RangerMixin:
             self._get_values(
                 left, right, root, weights,
             )
-            if self._estimator_type == "classifier":
+            if getattr(self, "_estimator_type", None) == "classifier":
                 values = [
                     np.bincount(v, weights=w, minlength=self.n_classes_).tolist()
                     if v

--- a/skranger/tree/_tree.py
+++ b/skranger/tree/_tree.py
@@ -201,4 +201,4 @@ class Tree:
     def value(self):
         """The constant prediction value of each node."""
         values = self.ranger_forest["forest"]["node_values"][0]
-        return np.reshape(values, (len(values), 1, 1))
+        return np.reshape(values, (len(values), 1, self.n_classes[0]))

--- a/tests/test_tools.py
+++ b/tests/test_tools.py
@@ -1,5 +1,6 @@
 import pytest
 
+from skranger.ensemble import RangerForestClassifier
 from skranger.ensemble import RangerForestRegressor
 
 
@@ -24,25 +25,51 @@ def test_plot():
 
 # FIXME not working yet
 @pytest.mark.skip()
-def test_shap(boston_X, boston_y):
+def test_shap_regressor(boston_X, boston_y):
     from shap import TreeExplainer
 
     forest = RangerForestRegressor()
     forest.fit(boston_X, boston_y)
 
-    explainer = TreeExplainer(model=forest, data=boston_X)
-    shap_values = explainer.shap_values(boston_X, check_additivity=True)
+    explainer = TreeExplainer(model=forest)
+    shap_values = explainer.shap_values(boston_X)
+    print(shap_values)
+
+
+# FIXME not working yet
+@pytest.mark.skip()
+def test_shap_classifier(iris_X, iris_y):
+    from shap import TreeExplainer
+
+    forest = RangerForestClassifier(enable_tree_details=True)
+    forest.fit(iris_X, iris_y)
+
+    explainer = TreeExplainer(model=forest)
+    shap_values = explainer.shap_values(iris_X)
     print(shap_values)
 
 
 @pytest.mark.skip()
-def test_shap_sklearn(boston_X, boston_y):
+def test_shap_sklearn_regressor(boston_X, boston_y):
     from shap import TreeExplainer
     from sklearn.ensemble import RandomForestRegressor
 
     forest = RandomForestRegressor()
     forest.fit(boston_X, boston_y)
 
-    explainer = TreeExplainer(model=forest, data=boston_X)
-    shap_values = explainer.shap_values(boston_X, check_additivity=True)
+    explainer = TreeExplainer(model=forest)
+    shap_values = explainer.shap_values(boston_X)
+    print(shap_values)
+
+
+@pytest.mark.skip()
+def test_shap_sklearn_classifier(iris_X, iris_y):
+    from shap import TreeExplainer
+    from sklearn.ensemble import RandomForestClassifier
+
+    forest = RandomForestClassifier()
+    forest.fit(iris_X, iris_y)
+
+    explainer = TreeExplainer(model=forest)
+    shap_values = explainer.shap_values(iris_X)
     print(shap_values)

--- a/tests/tree/test_classifier.py
+++ b/tests/tree/test_classifier.py
@@ -387,3 +387,4 @@ class TestRangerTreeClassifier:
         n_outputs = tree_.n_outputs
         n_classes = tree_.n_classes
         value = tree_.value
+        assert value.shape == (node_count, 1, len(np.unique(iris_y)))

--- a/tests/tree/test_regressor.py
+++ b/tests/tree/test_regressor.py
@@ -312,3 +312,4 @@ class TestRangerTreeRegressor:
         n_outputs = tree_.n_outputs
         n_classes = tree_.n_classes
         value = tree_.value
+        assert value.shape == (node_count, 1, 1)


### PR DESCRIPTION
Fixes https://github.com/crflynn/skranger/issues/66#issuecomment-959028691

Fixes the Tree.value attribute for classifiers. Instead of taking the weighted average as we do with regressors we take the weighted class count for each node.

Along with removing the `data` param, this allows us to create shap explainers. Unfortunately the explainer still segfaults when creating `shap_values`. Still unsure why.