### PR TITLE
drop 3.6, update poetry

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -62,7 +62,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [3.7.12, 3.8.12, 3.9.8, 3.10.0]
+        python-version: [3.7.12, 3.8.12, 3.9.8]
 
     steps:
     - name: Checkout
@@ -129,7 +129,7 @@ jobs:
     strategy:
       matrix:
         os: [macos-10.15, macos-11]
-        python-version: [3.7.12, 3.8.12, 3.9.8, 3.10.0]
+        python-version: [3.7.12, 3.8.12, 3.9.8]
     runs-on: ${{ matrix.os }}
 
     steps:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -126,11 +126,10 @@ jobs:
 
   macos:
 
+    runs-on: macos-latest
     strategy:
       matrix:
-        os: [macos-10.15, macos-11]
         python-version: [3.7.12, 3.8.12, 3.9.8]
-    runs-on: ${{ matrix.os }}
 
     steps:
     - name: Checkout

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -62,7 +62,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [3.6.12, 3.7.9, 3.8.6, 3.9.1]
+        python-version: [3.7.12, 3.8.12, 3.9.8, 3.10.0]
 
     steps:
     - name: Checkout
@@ -126,10 +126,11 @@ jobs:
 
   macos:
 
-    runs-on: macos-latest
     strategy:
       matrix:
-        python-version: [3.6.12, 3.7.9, 3.8.6, 3.9.1]
+        os: [macos-10.15, macos-11]
+        python-version: [3.7.12, 3.8.12, 3.9.8, 3.10.0]
+    runs-on: ${{ matrix.os }}
 
     steps:
     - name: Checkout

--- a/.tool-versions
+++ b/.tool-versions
@@ -1,2 +1,2 @@
-poetry 1.1.4
+poetry 1.1.11
 python 3.8.2


### PR DESCRIPTION
running into build errors with python 3.6 now. since 3.6 is EOL soon, just drop it from builds. also, update poetry.