### PR TITLE
Call `predict_quantile` by default if `quantiles` is set to `True`, `list` or `np.ndarray`

### DIFF
--- a/skranger/ensemble/regressor.py
+++ b/skranger/ensemble/regressor.py
@@ -92,7 +92,6 @@ class RangerForestRegressor(BaseRangerForest, RegressorMixin, BaseEstimator):
     def __init__(
         self,
         n_estimators=100,
-        *,
         verbose=False,
         mtry=0,
         importance="none",
@@ -278,7 +277,14 @@ class RangerForestRegressor(BaseRangerForest, RegressorMixin, BaseEstimator):
         terminal_node_forest = self._get_terminal_node_forest(X)
         terminal_nodes = np.atleast_2d(terminal_node_forest["predictions"]).astype(int)
 
-        if self.quantiles:
+        use_quantiles = False
+        if isinstance(self.quantiles, (list, np.ndarray)):
+            if len(self.quantiles) > 0:
+                use_quantiles = True
+        else:
+            use_quantiles = self.quantiles
+
+        if use_quantiles:
             self.random_node_values_ = np.empty(
                 (np.max(terminal_nodes) + 1, self.n_estimators)
             )
@@ -336,6 +342,8 @@ class RangerForestRegressor(BaseRangerForest, RegressorMixin, BaseEstimator):
         """
         if quantiles is not None:
             return self.predict_quantiles(X, quantiles)
+        if isinstance(self.quantiles, (list, np.ndarray)):
+            return self.predict_quantiles(X, self.quantiles)
         check_is_fitted(self)
         X = check_array(X)
         self._check_n_features(X, reset=False)


### PR DESCRIPTION
When using `RangerForestRegressor` with `quantiles=True` in a parameter optimization software (i.e. `tune-sklearn`) in order to optimize probabilistic metrics like [Continuous Ranked Probability Score (CRPS)](https://solarforecastarbiter-core.readthedocs.io/en/latest/generated/solarforecastarbiter.metrics.probabilistic.continuous_ranked_probability_score.html#solarforecastarbiter.metrics.probabilistic.continuous_ranked_probability_score), it is required the model ot output the 2D tensor corresponding to the `predict_quantiles` method. However, when making CRPS a score metric with the sklearn API with `make_score` function, in a final step, [it will call (always) the Ranger's `predict` method](https://github.com/scikit-learn/scikit-learn/blob/main/sklearn/metrics/_scorer.py#L258), so it is never going to predict quantiles in any way. 

Here is a brief example of what I am trying to explain:

```python
from sklearn.metrics import make_scorer
from skranger.ensemble import RangerForestRegressor
from tune_sklearn import TuneSearchCV
from solarforecastarbiter.metrics.probabilistic import continuous_ranked_probability_score as crps

param_dists = {
    'max_depth': (0, 50),
    'min_node_size': (10, 100),
    'n_estimators': (100, 1000),
    'split_rule': ['variance', 'extratrees', 'maxstat'],
}

m = RangerForestRegressor(quantiles=True)
gs = TuneSearchCV(m,
                  param_distributions=param_dists,
                  scoring=make_scorer(crps, greater_is_better=False),
)
gs.fit(X, y)  # Raise error: forecasts must be 2D arrays
```

I think the sklearn API is correct. To surpass this problem, I made some chages in skranger:
- First, I initialize `RangerForestRegressor` with `quantiles: Union[bool, list, np.ndarray]`. If `quantiles` receives any variable of that type, it will be in [*quantile mode*](https://github.com/crflynn/skranger/compare/master...r3v1:master#diff-1106e1ee8f942db6040a97fb66c3326c5a14a489eae8ad75330ceab689605175R280).
- Second, if the model is in *quantile mode*, then [it will call `predict_quantile` by default](https://github.com/crflynn/skranger/compare/master...r3v1:master#diff-1106e1ee8f942db6040a97fb66c3326c5a14a489eae8ad75330ceab689605175R345) when predicting.

**NOTE**: Additional logic should be implemented if a non-quantile prediction is required and *quantile mode* is enabled.
